### PR TITLE
ci: modernize workflows to Node.js 24 actions and drop Codecov

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -21,8 +21,4 @@ jobs:
         run: uv sync --dev
 
       - name: Run tests with coverage
-        run: uv run pytest --cov=metaboatrace.scrapers tests --cov-report=xml:coverage.xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          file: ./coverage.xml
+        run: uv run pytest --cov=metaboatrace.scrapers --cov-report=term-missing tests

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![GitHub Workflow Status](https://github.com/metaboatrace/scrapers/actions/workflows/publish.yml/badge.svg)
 ![GitHub Workflow Status](https://github.com/metaboatrace/scrapers/actions/workflows/tests.yml/badge.svg)
 ![GitHub Workflow Status](https://github.com/metaboatrace/scrapers/actions/workflows/lint.yml/badge.svg)
-![Coverage](https://img.shields.io/codecov/c/github/metaboatrace/scrapers.svg)
 ![PyPI version](https://img.shields.io/pypi/v/metaboatrace.scrapers.svg)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Python version](https://img.shields.io/badge/python-3.13-blue.svg)


### PR DESCRIPTION
## 概要
GitHub Actions ランナーの Node.js 20 actions 非推奨化（2026-09-16 にランナーから削除予定）に対応して各 action を Node.js 24 対応へ更新する。あわせて外部 SaaS の Codecov 連携を廃止し、カバレッジ計測を pytest-cov だけでローカル/CI 内完結にする。

## actions の更新
- `actions/checkout` v4 → v6
- `astral-sh/setup-uv` v4 → v8.2.0（setup-uv は floating な major タグ `v8` を公開していないためフルバージョンで固定）
- `actions/setup-python` v5 → v6

## Codecov 廃止
- `codecov/codecov-action` のアップロード step を削除（トークン・外部連携が不要に）
- tests のカバレッジ出力を `coverage.xml` 生成から `--cov-report=term-missing` に変更し、未カバー行を CI ログで確認できるように
- README の codecov バッジを削除

## 補足
- CI ワークフローのみの変更で PyPI パッケージ内容は変わらないため version の bump は不要。
- `publish.yml` の action 更新が main に反映されるのは次回リリース（release→main マージ）時。

🤖 Generated with [Claude Code](https://claude.com/claude-code)